### PR TITLE
Backward compatibility for pre ES2021

### DIFF
--- a/dist/index.cjs.js
+++ b/dist/index.cjs.js
@@ -1973,7 +1973,7 @@ function getset(model, channel, modifier) {
 	model = Array.isArray(model) ? model : [model];
 
 	for (const m of model) {
-		(limiters[m] ||= [])[channel] = modifier;
+		(limiters[m] = limiters[m] || [])[channel] = modifier;
 	}
 
 	model = model[0];


### PR DESCRIPTION
The objective is to make this module compatible with old code using pre ES2021. For example, winston3.3.3 depending on @dabh/diagnostics@^2 which pulls this module. (https://github.com/winstonjs/winston/issues/2586)