### PR TITLE
Update index.cjs.js: support for node14 syntax

### DIFF
--- a/dist/index.cjs.js
+++ b/dist/index.cjs.js
@@ -1973,7 +1973,7 @@ function getset(model, channel, modifier) {
 	model = Array.isArray(model) ? model : [model];
 
 	for (const m of model) {
-		(limiters[m] ||= [])[channel] = modifier;
+		(limiters[m] || (limiters[m] = []))[channel] = modifier;
 	}
 
 	model = model[0];


### PR DESCRIPTION
From 
(limiters[m] ||= [])[channel] = modifier;
to 
(limiters[m] || (limiters[m] = []))[channel] = modifier;